### PR TITLE
Add rake spec and make it the default Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ rescue LoadError
 end
 
 require 'rdoc/task'
+require 'rspec/core/rake_task'
 
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
@@ -15,3 +16,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
 end
 
 Bundler::GemHelper.install_tasks
+
+RSpec::Core::RakeTask.new
+
+task default: :spec


### PR DESCRIPTION
A good practice when it comes to Ruby project is to enable the default workflow:

1. clone the code
1. run `bundle` to install dependencies
1. run `rake` to run tests

This PR makes the last step possible by adding a `rake spec` task and making it the default.