### PR TITLE
Gets rid of class eval

### DIFF
--- a/lib/jump_in/authentication.rb
+++ b/lib/jump_in/authentication.rb
@@ -8,7 +8,7 @@ module JumpIn
       base.send :helper_method, :current_user, :logged_in? if
         base.respond_to? :helper_method
       base.const_set('GET_CURRENT_USER', [])
-      const_set('APP_MAIN_CONTROLLER', base)
+      const_set('JUMPIN_CONTROLLER', base)
     end
 
     # LOGGING IN

--- a/lib/jump_in/persistence/cookies.rb
+++ b/lib/jump_in/persistence/cookies.rb
@@ -7,14 +7,7 @@ module JumpIn
         klass.jumpin_callback :on_login,         :set_user_cookies
         klass.jumpin_callback :on_logout,        :remove_user_cookies
         klass.jumpin_callback :get_current_user, :current_user_from_cookies
-        klass::JUMPIN_CONTROLLER.class_eval do
-          def current_user_from_cookies
-            return nil unless cookies.signed[:jump_in_id] &&
-                              cookies.signed[:jump_in_class]
-            klass = cookies.signed[:jump_in_class].constantize
-            klass.find_by(id: cookies.signed[:jump_in_id])
-          end
-        end
+        klass::JUMPIN_CONTROLLER.include ApplicationControllerMethods
       end
 
       def set_user_cookies(user:)
@@ -28,6 +21,15 @@ module JumpIn
       def remove_user_cookies
         cookies.delete :jump_in_class
         cookies.delete :jump_in_id
+      end
+
+      module ApplicationControllerMethods
+        def current_user_from_cookies
+          return nil unless cookies.signed[:jump_in_id] &&
+                            cookies.signed[:jump_in_class]
+          klass = cookies.signed[:jump_in_class].constantize
+          klass.find_by(id: cookies.signed[:jump_in_id])
+        end
       end
     end
   end

--- a/lib/jump_in/persistence/cookies.rb
+++ b/lib/jump_in/persistence/cookies.rb
@@ -7,7 +7,7 @@ module JumpIn
         klass.jumpin_callback :on_login,         :set_user_cookies
         klass.jumpin_callback :on_logout,        :remove_user_cookies
         klass.jumpin_callback :get_current_user, :current_user_from_cookies
-        klass::APP_MAIN_CONTROLLER.class_eval do
+        klass::JUMPIN_CONTROLLER.class_eval do
           def current_user_from_cookies
             return nil unless cookies.signed[:jump_in_id] &&
                               cookies.signed[:jump_in_class]

--- a/lib/jump_in/persistence/cookies.rb
+++ b/lib/jump_in/persistence/cookies.rb
@@ -7,7 +7,6 @@ module JumpIn
         klass.jumpin_callback :on_login,         :set_user_cookies
         klass.jumpin_callback :on_logout,        :remove_user_cookies
         klass.jumpin_callback :get_current_user, :current_user_from_cookies
-
         klass::APP_MAIN_CONTROLLER.class_eval do
           def current_user_from_cookies
             return nil unless cookies.signed[:jump_in_id] &&

--- a/lib/jump_in/persistence/session.rb
+++ b/lib/jump_in/persistence/session.rb
@@ -7,7 +7,6 @@ module JumpIn
         klass.jumpin_callback :on_login,         :set_user_session
         klass.jumpin_callback :on_logout,        :remove_user_session
         klass.jumpin_callback :get_current_user, :current_user_from_session
-
         klass::APP_MAIN_CONTROLLER.class_eval do
           def current_user_from_session
             return nil unless session[:jump_in_id] && session[:jump_in_class]

--- a/lib/jump_in/persistence/session.rb
+++ b/lib/jump_in/persistence/session.rb
@@ -7,13 +7,7 @@ module JumpIn
         klass.jumpin_callback :on_login,         :set_user_session
         klass.jumpin_callback :on_logout,        :remove_user_session
         klass.jumpin_callback :get_current_user, :current_user_from_session
-        klass::JUMPIN_CONTROLLER.class_eval do
-          def current_user_from_session
-            return nil unless session[:jump_in_id] && session[:jump_in_class]
-            klass = session[:jump_in_class].constantize
-            klass.find_by(id: session[:jump_in_id])
-          end
-        end
+        klass::JUMPIN_CONTROLLER.include ApplicationControllerMethods
       end
 
       def set_user_session(user:)
@@ -25,6 +19,14 @@ module JumpIn
       def remove_user_session
         session.delete :jump_in_class
         session.delete :jump_in_id
+      end
+
+      module ApplicationControllerMethods
+        def current_user_from_session
+          return nil unless session[:jump_in_id] && session[:jump_in_class]
+          klass = session[:jump_in_class].constantize
+          klass.find_by(id: session[:jump_in_id])
+        end
       end
     end
   end

--- a/lib/jump_in/persistence/session.rb
+++ b/lib/jump_in/persistence/session.rb
@@ -7,7 +7,7 @@ module JumpIn
         klass.jumpin_callback :on_login,         :set_user_session
         klass.jumpin_callback :on_logout,        :remove_user_session
         klass.jumpin_callback :get_current_user, :current_user_from_session
-        klass::APP_MAIN_CONTROLLER.class_eval do
+        klass::JUMPIN_CONTROLLER.class_eval do
           def current_user_from_session
             return nil unless session[:jump_in_id] && session[:jump_in_class]
             klass = session[:jump_in_class].constantize

--- a/spec/dummy/spec/modules/authentication_spec.rb
+++ b/spec/dummy/spec/modules/authentication_spec.rb
@@ -21,14 +21,20 @@ describe AuthenticationController, type: :controller do
   let(:user_wsp) { FactoryGirl.create(:user_with_secure_password) }
   after(:all) { JumpIn.instance_variable_set('@configuration', nil) }
 
+  context 'JUMPIN_CONTROLLER' do
+    it 'is available in current controller' do
+      expect(subject.class::JUMPIN_CONTROLLER).to eq(AppMainController)
+    end
+  end
+
   context ".jumpin_callback" do
     context 'persistence' do
-      it "it adds default constants while including Session & Cookies" do
+      it "adds default constants while including Session & Cookies" do
         expect(subject.class.constants).to include(:ON_LOGIN)
         expect(subject.class.constants).to include(:ON_LOGOUT)
       end
 
-      it "it adds GET_CURRENT_USER to ApplicationController" do
+      it "adds GET_CURRENT_USER to ApplicationController" do
         expect(AppMainController.constants).to include(:GET_CURRENT_USER)
       end
 


### PR DESCRIPTION
- gets rid of `class eval` in module `Session` and `Cookies`, adds modules `ApplicationControllerMethods` to be included